### PR TITLE
Support Silex 2.x and Pimple 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "amstaffix/pagination": "~1.1"
+        "amstaffix/pagination": "~1.1",
+        "pimple/pimple": "^3.0"
     },
     "require-dev": {
         "silex/silex": "*",

--- a/source/PaginationServiceProvider.php
+++ b/source/PaginationServiceProvider.php
@@ -8,8 +8,8 @@
 namespace Kilte\Silex\Pagination;
 
 use Kilte\Pagination\Pagination;
-use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 
 /**
  * PaginationServiceProvider Class.
@@ -19,7 +19,7 @@ class PaginationServiceProvider implements ServiceProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
         $app['pagination.per_page'] = isset($app['pagination.per_page']) ? (int) $app['pagination.per_page'] : 20;
         $app['pagination.neighbours'] = isset($app['pagination.neighbours']) ? (int) $app['pagination.neighbours'] : 4;
@@ -35,14 +35,5 @@ class PaginationServiceProvider implements ServiceProviderInterface
                 return new Pagination($total, $current, $perPage, $neighbours);
             }
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @codeCoverageIgnore
-     */
-    public function boot(Application $app)
-    {
     }
 }

--- a/source/Tests/PaginationServiceProviderTest.php
+++ b/source/Tests/PaginationServiceProviderTest.php
@@ -8,7 +8,7 @@
 namespace Kilte\Silex\Pagination\Tests;
 
 use Kilte\Silex\Pagination\PaginationServiceProvider;
-use Silex\Application;
+use Pimple\Container;
 
 /**
  * Class PaginationServiceProviderTest.
@@ -17,7 +17,7 @@ class PaginationServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testRegisterDefaultValues()
     {
-        $app = new Application();
+        $app = new Container();
         $app->register(new PaginationServiceProvider());
         $this->assertEquals(20, $app['pagination.per_page']);
         $this->assertEquals(4, $app['pagination.neighbours']);
@@ -28,7 +28,7 @@ class PaginationServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testRegisterCustomValues()
     {
-        $app = new Application();
+        $app = new Container();
         $app->register(
             new PaginationServiceProvider(),
             array('pagination.per_page' => 2, 'pagination.neighbours' => 2)


### PR DESCRIPTION
This is a breaking, although a needed change to use the provider with Silex 2.x.
